### PR TITLE
Update Dockerfile to use python:3.11-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 ENV DISABLE_LOOP=false
 ENV HEARTBEAT_TIMEOUT=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim⁠
+FROM python:3.12-slim
 
 ENV DISABLE_LOOP=false
 ENV HEARTBEAT_TIMEOUT=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.12-slim⁠
 
 ENV DISABLE_LOOP=false
 ENV HEARTBEAT_TIMEOUT=60


### PR DESCRIPTION
Switched from python:slim to python:3.11-slim in the Dockerfile to fix compatibility issues:

cgi module is missing in Python 3.13+ ([details](https://stackoverflow.com/questions/79022412/chaquopy-modulenotfounderror-no-module-named-cgi)).
Python 3.12 threw No module named 'urllib3.packages.six.moves'.
Python 3.11 works without these issues.